### PR TITLE
Add 188 Endpoint for Itron 500G gas meter

### DIFF
--- a/metermon.py
+++ b/metermon.py
@@ -86,7 +86,7 @@ while True:
             msg['Type'] = "Electric"
             msg['Consumption'] = data['Message']['Consumption'] / 100.0 # convert to kWh
             msg['Unit'] = "kWh"
-        elif data['Message']['EndpointType'] in (2,9,12): # gas meter
+        elif data['Message']['EndpointType'] in (2,9,12,188): # gas meter
             msg['Type'] = "Gas"
             msg['Consumption'] = data['Message']['Consumption']
             msg['Unit'] = "ft^3"


### PR DESCRIPTION
My Itron 500G gas meter reports a SCM+ endpoint type of 188.