### PR TITLE
Add support for adjusting `-symbollength`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ If the `METERMON_SEND_BY_ID` environment variable is set to `true`, metermon wil
 
 Metermon will report its status on the `[MQTT_TOPIC_PREFIX]/status` topic via retained messages. Metermon reports `Online` once it connects to the broker. Upon disconnect, the broker will report `Offline`.
 
+### Performance Tuning
+
+By adjusting the `RTLAMR_SYMBOL_LEN` environment variable, sample rates can be modified to reduce CPU load. See documentation of this feature [here](https://github.com/bemasher/rtlamr/wiki/Symbol-Length) and a discussion of the potential performance impacts [here](https://github.com/bemasher/rtlamr/issues/57#issuecomment-246166300).
+
 ## Running via Docker
 
 Pull the image. If using raspberry pi or similar use `arm` in place of `[tag]`. The `latest` tag will pull the `amd64` image:
@@ -81,6 +85,7 @@ docker run -d -e MQTT_BROKER_HOST=[host] -e RTL_TCP_SERVER=[server] seanauff/met
 | RTL_TCP_SERVER    |127.0.0.1:1234 |`server:port` that your rtl_tcp instance is listening on |
 | RTLAMR_MSGTYPE    |all|List of message types to listen for. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration)|
 | RTLAMR_FILTERID   |               |List of meter IDs to look for. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration)       |
+| RTLAMR_SYMBOL_LEN | 72            |Adjust sample rate by setting the length of each symbol. See [rtlamr wiki](https://github.com/bemasher/rtlamr/wiki/Symbol-Length)       |
 | RTLAMR_UNIQUE     | true          |Suppress duplicate messages from each meter. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration) |
 | METERMON_SEND_RAW | false         |Set to `true` to enable sending the raw json from rtlamr to the `[MQTT_TOPIC_PREFIX]/raw` topic      |
 | METERMON_SEND_BY_ID | false       |Set to `true` to enable sending the processed json to the `[MQTT_TOPIC_PREFIX]/[UNIQUE_ID_OF_METER]` topic. |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Metermon will report its status on the `[MQTT_TOPIC_PREFIX]/status` topic via re
 
 ### Performance Tuning
 
-By adjusting the `RTLAMR_SYMBOL_LEN` environment variable, sample rates can be modified to reduce CPU load. See documentation of this feature [here](https://github.com/bemasher/rtlamr/wiki/Symbol-Length) and a discussion of the potential performance impacts [here](https://github.com/bemasher/rtlamr/issues/57#issuecomment-246166300).
+By adjusting the `RTLAMR_SYMBOLLENGTH` environment variable, sample rates can be modified to reduce CPU load. See documentation of this feature [here](https://github.com/bemasher/rtlamr/wiki/Symbol-Length) and a discussion of the potential performance impacts [here](https://github.com/bemasher/rtlamr/issues/57#issuecomment-246166300).
 
 ## Running via Docker
 
@@ -85,7 +85,7 @@ docker run -d -e MQTT_BROKER_HOST=[host] -e RTL_TCP_SERVER=[server] seanauff/met
 | RTL_TCP_SERVER    |127.0.0.1:1234 |`server:port` that your rtl_tcp instance is listening on |
 | RTLAMR_MSGTYPE    |all|List of message types to listen for. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration)|
 | RTLAMR_FILTERID   |               |List of meter IDs to look for. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration)       |
-| RTLAMR_SYMBOL_LEN | 72            |Adjust sample rate by setting the length of each symbol. See [rtlamr wiki](https://github.com/bemasher/rtlamr/wiki/Symbol-Length)       |
+| RTLAMR_SYMBOLLENGTH | 72            |Adjust sample rate by setting the length of each symbol. See [rtlamr wiki](https://github.com/bemasher/rtlamr/wiki/Symbol-Length)       |
 | RTLAMR_UNIQUE     | true          |Suppress duplicate messages from each meter. See [rtlamr config](https://github.com/bemasher/rtlamr/wiki/Configuration) |
 | METERMON_SEND_RAW | false         |Set to `true` to enable sending the raw json from rtlamr to the `[MQTT_TOPIC_PREFIX]/raw` topic      |
 | METERMON_SEND_BY_ID | false       |Set to `true` to enable sending the processed json to the `[MQTT_TOPIC_PREFIX]/[UNIQUE_ID_OF_METER]` topic. |

--- a/docker_compose.yaml
+++ b/docker_compose.yaml
@@ -13,7 +13,7 @@ services:
       - RTL_TCP_SERVER=127.0.0.1:1234
       - RTLAMR_MESGTYPE=all
       #- RTLAMR_FILTERID=
-      #- RTLAMR_SYMBOL_LEN=72
+      #- RTLAMR_SYMBOLLENGTH=72
       - RTLAMR_UNIQUE=true
       - METERMON_SEND_RAW=false
       - METERMON_SEND_BY_ID=false

--- a/docker_compose.yaml
+++ b/docker_compose.yaml
@@ -13,6 +13,7 @@ services:
       - RTL_TCP_SERVER=127.0.0.1:1234
       - RTLAMR_MESGTYPE=all
       #- RTLAMR_FILTERID=
+      #- RTLAMR_SYMBOL_LEN=72
       - RTLAMR_UNIQUE=true
       - METERMON_SEND_RAW=false
       - METERMON_SEND_BY_ID=false

--- a/metermon.py
+++ b/metermon.py
@@ -15,8 +15,6 @@ MQTT_PASSWORD     = os.getenv('MQTT_PASSWORD',"")
 MQTT_TOPIC_PREFIX = os.getenv('MQTT_TOPIC_PREFIX',"metermon")
 RTL_TCP_SERVER    = os.getenv('RTL_TCP_SERVER',"127.0.0.1:1234")
 RTLAMR_MSGTYPE    = os.getenv('RTLAMR_MSGTYPE',"all")
-RTLAMR_FILTERID   = os.getenv('RTLAMR_FILTERID',"")
-RTLAMR_SYMBOL_LEN = os.getenv('RTLAMR_SYMBOL_LEN',"")
 RTLAMR_UNIQUE     = os.getenv('RTLAMR_UNIQUE',"true")
 METERMON_SEND_RAW = os.getenv('METERMON_SEND_RAW',"False")
 METERMON_SEND_BY_ID = os.getenv('METERMON_SEND_BY_ID', "False")
@@ -54,11 +52,6 @@ cmdargs = [
     f'-msgtype={RTLAMR_MSGTYPE}',
     f'-unique={RTLAMR_UNIQUE}',
 ]
-if RTLAMR_FILTERID:
-    cmdargs.append(f'-filterid={RTLAMR_FILTERID}')
-
-if RTLAMR_SYMBOL_LEN:
-    cmdargs.append(f'-symbollength={RTLAMR_SYMBOL_LEN}')
 
 proc = subprocess.Popen(cmdargs, stdout=subprocess.PIPE)
 

--- a/metermon.py
+++ b/metermon.py
@@ -16,6 +16,7 @@ MQTT_TOPIC_PREFIX = os.getenv('MQTT_TOPIC_PREFIX',"metermon")
 RTL_TCP_SERVER    = os.getenv('RTL_TCP_SERVER',"127.0.0.1:1234")
 RTLAMR_MSGTYPE    = os.getenv('RTLAMR_MSGTYPE',"all")
 RTLAMR_FILTERID   = os.getenv('RTLAMR_FILTERID',"")
+RTLAMR_SYMBOL_LEN = os.getenv('RTLAMR_SYMBOL_LEN',"")
 RTLAMR_UNIQUE     = os.getenv('RTLAMR_UNIQUE',"true")
 METERMON_SEND_RAW = os.getenv('METERMON_SEND_RAW',"False")
 METERMON_SEND_BY_ID = os.getenv('METERMON_SEND_BY_ID', "False")
@@ -46,10 +47,20 @@ client.connect(MQTT_BROKER_HOST, port=MQTT_BROKER_PORT)
 client.loop_start()
 
 # start RTLAMR
+cmdargs = [
+    'rtlamr',
+    '-format=json',
+    f'-server={RTL_TCP_SERVER}',
+    f'-msgtype={RTLAMR_MSGTYPE}',
+    f'-unique={RTLAMR_UNIQUE}',
+]
 if RTLAMR_FILTERID:
-    proc = subprocess.Popen(['rtlamr', '-server='+RTL_TCP_SERVER,'-msgtype='+RTLAMR_MSGTYPE, '-filterid='+RTLAMR_FILTERID,'-format=json','-unique='+RTLAMR_UNIQUE],stdout=subprocess.PIPE)
-else:
-    proc = subprocess.Popen(['rtlamr', '-server='+RTL_TCP_SERVER,'-msgtype='+RTLAMR_MSGTYPE, '-format=json','-unique='+RTLAMR_UNIQUE],stdout=subprocess.PIPE)
+    cmdargs.append(f'-filterid={RTLAMR_FILTERID}')
+
+if RTLAMR_SYMBOL_LEN:
+    cmdargs.append(f'-symbollength={RTLAMR_SYMBOL_LEN}')
+
+proc = subprocess.Popen(cmdargs, stdout=subprocess.PIPE)
 
 # read output of RTLAMR
 while True:


### PR DESCRIPTION
The default `-symbollength` used by `rtlamr` is 72, which defines a sample rate that _may_ be higher than necessary for some users. A lower sample rate can reduce CPU consumption without impacting functionality.

Please see discussion [here](https://github.com/bemasher/rtlamr/issues/57#issuecomment-246166300) and documentation [here](https://github.com/bemasher/rtlamr/wiki/Symbol-Length).

In my case I can use a sample length of `8` for an r900 water meter with a significantly reduced CPU load.