### PR TITLE
Run python script unbuffered to fix Docker logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN go install
 
 ADD metermon.py .
 
-CMD ["python3", "./metermon.py"]
+CMD ["python3", "-u", "./metermon.py"]


### PR DESCRIPTION
The print statements in the Python script do not show up in Docker logs. Running in unbuffered mode fixes this.