### PR TITLE
Add more R900 water meter attributes

### DIFF
--- a/metermon.py
+++ b/metermon.py
@@ -20,6 +20,29 @@ RTLAMR_UNIQUE     = os.getenv('RTLAMR_UNIQUE',"true")
 METERMON_SEND_RAW = os.getenv('METERMON_SEND_RAW',"False")
 METERMON_SEND_BY_ID = os.getenv('METERMON_SEND_BY_ID', "False")
 
+R900_LOOKUP = {
+    "HISTORY": {
+        0: "0",
+        1: "1-2",
+        2: "3-7",
+        3: "8-14",
+        4: "15-21",
+        5: "22-34",
+        6: "35+",
+    },
+    "INTENSITY": {
+        0: "None",
+        1: "Low",
+        2: "High",
+    }
+}
+R900_ATTRIBS = {
+    "Leak": "HISTORY",
+    "NoUse": "HISTORY",
+    "BackFlow": "INTENSITY",
+    "LeakNow": "INTENSITY",
+}
+
 # The callback for when the client receives a CONNACK response from the server.
 def on_connect(client, userdata, flags, rc):
     # print connection statement
@@ -112,6 +135,10 @@ while True:
         msg['ID'] = str(data['Message']['ID'])
         msg['Consumption'] = data['Message']['Consumption'] / 10.0 # convert to gal
         msg['Unit'] = "gal"
+        for attr, kind in R900_ATTRIBS.items():
+            value = data['Message'].get(attr)
+            if value is not None:
+                msg[attr] = R900_LOOKUP[kind][value]
     # R900bcd messages
     elif msg['Protocol'] == "R900BCD":
         msg['Type'] = "Water"


### PR DESCRIPTION
Adds more information in the MQTT payloads for R900 water meters:
* `BackFlow`: Intensity of water backflow over the past 35 days
* `LeakNow`: Intensity of water leaks over the past 24 hours
* `Leak`: Number of historical days where water leaks have been detected
* `NoUse`: Number of historical days where no water use has been detected

It may make more sense to add these using a different format or as separate payloads.