### PR TITLE
Add water endpoint type 171 to SCM+

### DIFF
--- a/metermon.py
+++ b/metermon.py
@@ -97,7 +97,7 @@ while True:
             msg['Type'] = "Gas"
             msg['Consumption'] = data['Message']['Consumption']
             msg['Unit'] = "ft^3"
-        elif data['Message']['EndpointType'] in (3,11,13): # water meter
+        elif data['Message']['EndpointType'] in (3,11,13,171): # water meter
             msg['Type'] = "Water"
             msg['Consumption'] = data['Message']['Consumption'] / METERMON_WATER_DIVISOR # convert to gal
             msg['Unit'] = "gal"


### PR DESCRIPTION
My Itron 100W-R uses  SCM+ with an id of 0xAB / 171.  I had to add this id value so it would be detected by metermon.

This is the stdout of rtlamr when run natively
`
{Time:2021-06-11T15:37:47.451 SCM+:{ProtocolID:0x1E EndpointType:0xAB EndpointID:  71508809 Consumption:     37781 Tamper:0x2500 PacketCRC:0x0868}}`

After I added 171, this is my metermon stdout
`{"Protocol": "SCM+", "Type": "Water", "ID": "71508809", "Consumption": 37799.0, "Unit": "gal"}`