### PR TITLE
Update metermon.py

### DIFF
--- a/metermon.py
+++ b/metermon.py
@@ -116,7 +116,7 @@ while True:
             msg['Type'] = "Electric"
             msg['Consumption'] = data['Message']['Consumption'] / METERMON_ELECTRIC_DIVISOR # convert to kWh
             msg['Unit'] = "kWh"
-        elif data['Message']['EndpointType'] in (2,9,12,188): # gas meter
+        elif data['Message']['EndpointType'] in (2,9,12,156,188): # gas meter
             msg['Type'] = "Gas"
             msg['Consumption'] = data['Message']['Consumption']
             msg['Unit'] = "ft^3"


### PR DESCRIPTION
Need to extend SCM+ message to support new gas meter (with EndpointType:0x9C) that was not among the supported codes.
GAS meter spec: https://www.itron.com/-/media/feature/products/documents/spec-sheet/100g-dls-spec-sheet.pdf
Obtained the code using rtlamr debugging.

Debugging log:
C:\Users\giveaway\go\bin>rtlamr -msgtype=scm+
20:01:26.528746 decode.go:45: CenterFreq: 912600155
20:01:26.529803 decode.go:46: SampleRate: 2359296
20:01:26.530323 decode.go:47: DataRate: 32768
20:01:26.530845 decode.go:48: ChipLength: 72
20:01:26.531921 decode.go:49: PreambleSymbols: 16
20:01:26.532459 decode.go:50: PreambleLength: 2304
20:01:26.533014 decode.go:51: PacketSymbols: 128
20:01:26.536139 decode.go:52: PacketLength: 18432
20:01:26.536671 decode.go:59: Protocols: scm+
20:01:26.536671 decode.go:60: Preambles: 0001011010100011
20:01:26.537734 main.go:124: GainCount: 29
{Time:2021-11-24T20:01:41.338 SCM+:{ProtocolID:0x1E EndpointType:0x07 EndpointID:1550493949 Consumption:    328816 Tamper:0x0100 PacketCRC:0x3C0C}}
**{Time:2021-11-24T20:02:05.619 SCM+:{ProtocolID:0x1E EndpointType:0x9C EndpointID:  75387939 Consumption:     12304 Tamper:0x0100 PacketCRC:0x28C1}}**
20:03:22.880442 main.go:339: Received Signal: interrupt