### PR TITLE
Add timestamp to messages

### DIFF
--- a/metermon.py
+++ b/metermon.py
@@ -87,12 +87,13 @@ while True:
     if not line:
         break
     data=json.loads(line)
-    msg=json.loads('{"Protocol":"Unknown","Type":"Unknown","ID":"Unknown","Consumption":0,"Unit":"Unknown"}')
+    msg=json.loads('{"Protocol":"Unknown","Time":"Unknown","Type":"Unknown","ID":"Unknown","Consumption":0,"Unit":"Unknown"}')
 
     # read data, create json objects, and publish MQTT message for every meter message received
 
     # set Protocol
     msg['Protocol'] = data['Type']
+    msg['Time'] = data['Time']
 
     # SCM messages
     if msg['Protocol'] == "SCM":


### PR DESCRIPTION
This forwards the timestamp included in the meter data in the message that metermon publishes, so users can more easily identify when the last update happened.

Time information is useful when trying to identify a meter with unknown ID and/or debug various issues too.